### PR TITLE
feat(core) added ManualJudgment filter

### DIFF
--- a/app/scripts/modules/core/src/filterModel/FilterModelService.ts
+++ b/app/scripts/modules/core/src/filterModel/FilterModelService.ts
@@ -219,6 +219,8 @@ export class FilterModelService {
             clear() {
               // do not reuse the modelVal variable - it's possible it has been reassigned since the tag was created
               const toClearFrom: ITrueKeyModel = model.sortFilter[key] as ITrueKeyModel;
+              model.sortFilter.filterStages =
+                value === 'MANUAL_JUDGMENT' ? !model.sortFilter.filterStages : model.sortFilter.filterStages;
               delete toClearFrom[value];
               model.applyParamsToUrl();
             },

--- a/app/scripts/modules/core/src/filterModel/IFilterModel.ts
+++ b/app/scripts/modules/core/src/filterModel/IFilterModel.ts
@@ -27,6 +27,8 @@ export interface ISortFilter {
   count: number;
   detail: ITrueKeyModel;
   filter: string;
+  filterStages: boolean;
+  stages: ITrueKeyModel;
   groupBy: string;
   instanceSort: string;
   instanceType: ITrueKeyModel;

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -44,6 +44,8 @@ export interface IExecutionProps {
   cancelHelpText?: string;
   cancelConfirmationText?: string;
   scrollIntoView?: boolean; // should really only be set to ensure scrolling on initial page load deep link
+  goToParent: (executionId: string, name: string) => void;
+  manualJudgment: any;
 }
 
 export interface IExecutionState {
@@ -286,6 +288,15 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
       });
   };
 
+  private finalChild = (id: string, name: string) => {
+    const node = this.props.manualJudgment[id];
+    if (node) {
+      this.finalChild(node[0].id, node[0].name);
+    } else {
+      this.props.goToParent(id, name);
+    }
+  };
+
   public render() {
     const {
       application,
@@ -311,6 +322,11 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
         key={stage.refId}
         application={application}
         execution={execution}
+        manualJudgment={
+          this.props.manualJudgment !== undefined && this.props.manualJudgment[this.props.execution.id]
+            ? this.props.manualJudgment[this.props.execution.id]
+            : []
+        }
         stage={stage}
         onClick={this.toggleDetails}
         active={this.isActive(stage.index)}

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
@@ -42,3 +42,11 @@
     position: relative;
   }
 }
+
+.execution-marker-waiting {
+  color: var(--color-black);
+  background-color: var(--color-alert) !important;
+  .fa {
+    color: var(--color-black) !important ;
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -37,6 +37,9 @@ export interface IExecutionGroupProps {
   group: IExecutionGroup;
   application: Application;
   parent: HTMLDivElement;
+  goToParent: (executionId: string, name: string) => void;
+  manualJudgment: any;
+  id: string;
 }
 
 export interface IExecutionGroupState {
@@ -237,6 +240,8 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
         {executions.map((execution) => (
           <Execution
             key={execution.id}
+            goToParent={this.props.goToParent}
+            manualJudgment={this.props.manualJudgment}
             execution={execution}
             pipelineConfig={pipelineConfig}
             application={this.props.application}
@@ -248,7 +253,7 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
   }
 
   public render(): React.ReactElement<ExecutionGroup> {
-    const { group } = this.props;
+    const { group, goToParent } = this.props;
     const { displayExecutionActions, pipelineConfig, triggeringExecution, showingDetails } = this.state;
     const pipelineDisabled = pipelineConfig && pipelineConfig.disabled;
     const pipelineDescription = pipelineConfig && pipelineConfig.description;
@@ -286,7 +291,7 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
     }
 
     return (
-      <div className={`execution-group ${showingDetails ? 'showing-details' : 'details-hidden'}`}>
+      <div className={`execution-group ${showingDetails ? 'showing-details' : 'details-hidden'}`} id={this.props.id}>
         {group.heading && (
           <div className="clickable sticky-header" onClick={this.handleHeadingClicked}>
             <div className={`execution-group-heading ${pipelineDisabled ? 'inactive' : 'active'}`}>
@@ -368,6 +373,7 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
                 </div>
               )}
               <RenderWhenVisible
+                goToParent={goToParent}
                 container={this.props.parent}
                 disableHide={showingDetails}
                 initiallyVisible={showingDetails}

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
@@ -269,6 +269,12 @@ export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IE
                 <FilterStatus status="STOPPED" label="Stopped" refresh={this.refreshExecutions} />
                 <FilterStatus status="PAUSED" label="Paused" refresh={this.refreshExecutions} />
                 <FilterStatus status="BUFFERED" label="Buffered" refresh={this.refreshExecutions} />
+                <FilterStages
+                  status="RUNNING"
+                  stages="MANUAL_JUDGMENT"
+                  label="Manual Judgment"
+                  refresh={this.refreshExecutions}
+                />
               </div>
             </FilterSection>
           </div>
@@ -357,7 +363,34 @@ const FilterStatus = (props: { status: string; label: string; refresh: () => voi
   return (
     <div className="checkbox">
       <label>
-        <input type="checkbox" checked={sortFilter.status[props.status] || false} onChange={changed} />
+        <input
+          type="checkbox"
+          checked={sortFilter.status[props.status] || false}
+          disabled={props.label.toUpperCase() == 'RUNNING' && sortFilter.filterStages}
+          onChange={changed}
+        />
+        {props.label}
+      </label>
+    </div>
+  );
+};
+
+const FilterStages = (props: { status: string; stages: string; label: string; refresh: () => void }): JSX.Element => {
+  const sortFilter = ExecutionState.filterModel.asFilterModel.sortFilter;
+  const applyParams = !ExecutionState.filterModel.asFilterModel.sortFilter.status['RUNNING'];
+
+  const changed = () => {
+    sortFilter.filterStages = !sortFilter.filterStages;
+    sortFilter.stages[props.stages] = sortFilter.filterStages ? true : false;
+    if (applyParams) {
+      sortFilter.status[props.status] = !sortFilter.status[props.status];
+    }
+    props.refresh();
+  };
+  return (
+    <div className="checkbox">
+      <label>
+        <input type="checkbox" checked={sortFilter.filterStages} onChange={changed} />
         {props.label}
       </label>
     </div>

--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -365,6 +365,7 @@ export class ExecutionFilterService {
   }
 
   public static clearFilters(): void {
+    ExecutionState.filterModel.asFilterModel.sortFilter.filterStages = false;
     ExecutionState.filterModel.asFilterModel.clearFilters();
     ExecutionState.filterModel.asFilterModel.applyParamsToUrl();
   }

--- a/app/scripts/modules/core/src/projects/dashboard/pipeline/ProjectPipeline.tsx
+++ b/app/scripts/modules/core/src/projects/dashboard/pipeline/ProjectPipeline.tsx
@@ -54,6 +54,7 @@ export class ProjectPipeline extends React.Component<IProjectPipelineProps, IPro
     const stages = execution.stageSummaries.map((stage) => (
       <ExecutionMarker
         key={stage.refId}
+        manualJudgment={[]}
         {...this.props}
         stage={stage}
         onClick={this.handleStageClick}

--- a/app/scripts/modules/core/src/utils/RenderWhenVisible.tsx
+++ b/app/scripts/modules/core/src/utils/RenderWhenVisible.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export interface IRenderWhenVisibleProps {
+  goToParent: (executionId: any, name: string) => void;
   // not valid without a container in px (IntersectionObserver doesn't do so good with null root but non-null rootMargin)
   bufferHeight?: number;
   // best guess to height of non-rendered content (in px)


### PR DESCRIPTION
## Motivation and Rationale

If there are many pipelines it may be difficult for the user to serially check all the pipelines that are waiting for manual judgement. We need an Easy way to filter for pipelines waiting on Manual Judgment.

If we have a pipeline that is waiting on manual judgement then all the other pipelines that are waiting for this pipeline to be executed will be in the waiting stage. Clicking on any of the waiting stages will directly take you to the pipeline waiting on manual judgment.

## Design

1. Enhanced FilterModelService.ts to

added a filter tag for manual judgment and enhanced the clear filter functionality to clear manual judgment filter.

2. Enhanced IFilterModel to

added filterStages and stages to ISortFilter

3. Enhanced Execution.tsx to

added goToParent and manualJudgment to IExecutionProps
added a finalChild function that recursively finds the final child pipeline waiting on manual judgment.

4. Enhanced ExecutionMarker.tsx  to

Added a manual judgment status whether the stage’s child pipeline is waiting on manual Judgment.
Added the functionality so when a stage whose child pipeline is waiting on manual judgment is clicked then it scrolls to the leaf pipeline waiting on the manual judgment.

5. Enhanced executionMarker.less to

added a visual indicator to the stages waiting on manual judgment.

5. Enhanced ExecutionGroups.tsx to

added an id to the Execution group level so that we can scroll to the execution group in case the execution group is collapsed.

6. Enhanced ExecutionGroup.tsx  to

added a function to go to root pipeline waiting on manual judgment. if the execution group is collapsed then it will move the focus to the execution group header instead.
created a function to filter all the executions that contain manual judgement
Created a object containing all executions that are waiting on manual judgment and it's immidiate child

7. Enhanced ExecutionFilterModel.ts to 
added a filterstages property to sortfilter to extend the functionality and to reuse the same object to add other filters to the stages in future.

8. Enhanced ExecutionFilters.tsx to 
created a new component to be used for stage filter for filtering Manual Judgment filter. it can be reused to add more stage filter in the future.

9. Enhanced executionFilter.service.ts to 

enhance the clearFilters function to clear all the stageFilters also.

10. Enhanced ProjectPipeline.tsx to

add a default value to support the scroll to leaf if pipeline is waiting on manual judgment functionality.
