### PR TITLE
feat(core/ManualJudgment): Enhanced Manual Judgement Cross Applicatio…

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -36,6 +36,7 @@ export interface IFeatures {
   managedDelivery?: boolean;
   managedServiceAccounts?: boolean;
   managedResources?: boolean;
+  manualJudgementEnabled?: boolean;
   notifications?: boolean;
   pagerDuty?: boolean;
   pipelines?: boolean;

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -324,7 +324,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
         execution={execution}
         manualJudgment={
           this.props.manualJudgment !== undefined && this.props.manualJudgment[this.props.execution.id]
-            ? this.props.manualJudgment[this.props.execution.id]
+            ? this.props.manualJudgment
             : []
         }
         onWait={this.finalChild}

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -119,6 +119,10 @@ export class ExecutionService {
       });
   }
 
+  public getCrossApplicationExecutionContext(executionId: string): PromiseLike<IExecution> {
+    return API.one('pipelines', executionId).get();
+  }
+
   public transformExecutions(application: Application, executions: IExecution[], currentData: IExecution[] = []): void {
     if (!executions || !executions.length) {
       return;

--- a/settings.js
+++ b/settings.js
@@ -24,6 +24,7 @@ const iapRefresherEnabled = process.env.IAP_REFRESHER_ENABLED === 'true' ? true 
 const managedDeliveryEnabled = process.env.MANAGED_DELIVERY_ENABLED === 'true';
 const managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED === 'true';
 const managedResourcesEnabled = process.env.MANAGED_RESOURCES_ENABLED === 'true';
+const manualJudgementEnabled = process.env.MANUAL_JUDGEMENT_ENABLED === 'true';
 const onDemandClusterThreshold = process.env.ON_DEMAND_CLUSTER_THRESHOLD || '350';
 const reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
 const templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
@@ -79,6 +80,7 @@ window.spinnakerSettings = {
     managedDelivery: managedDeliveryEnabled,
     managedServiceAccounts: managedServiceAccountsEnabled,
     managedResources: managedResourcesEnabled,
+    manualJudgementEnabled: manualJudgementEnabled,
     notifications: false,
     pagerDuty: false,
     pipelineTemplates: false,


### PR DESCRIPTION
This is part of: Enhanced ManualJudgement

Enhanced settings.js to

Added a feature flag manualJudgementEnabled to enable/disable cross application manual judgement feature.

Enhanced ExecutionMarker.tsx to
1. If leaf node of a pipeline execution resides in another application then reusing the UiRef component for redirection to leaf node waiting for manual judgement.
2. If leaf node of a pipeline execution resides in same application then it shifts the focus to the leaf node waiting for manual judgement.
3. If the stage durations setting is disabled , show a waiting icon.

Enhanced ExecutionGroups.tsx  to
recursively checks if any leaf node is waiting on manual judgement that resides in another application 

Enhanced execution.service.ts to 
added a method to get the execution context of a pipeline.